### PR TITLE
Fix edition reversion

### DIFF
--- a/webapp/templates/mandelbrot.html
+++ b/webapp/templates/mandelbrot.html
@@ -65,7 +65,8 @@
 
     let currentJobId = "";
     let startTime = 0;
-    let resolution = 1028;
+    // Default resolution matches the input field's value
+    let resolution = 1024;
 
     const progressDiv = document.getElementById('progress');
     const canvas = document.getElementById('mandelCanvas');


### PR DESCRIPTION
## Summary
- keep scheduler and worker Rust edition at 2024
- ensure Mandelbrot default resolution matches input

## Testing
- `cargo check` *(fails: Could not connect to crates.io)*